### PR TITLE
dynamically added braintree library gets removed when not needed

### DIFF
--- a/src/app/braintree/directives/braintreescript.directive.ts
+++ b/src/app/braintree/directives/braintreescript.directive.ts
@@ -1,17 +1,23 @@
-import { Directive, OnInit } from '@angular/core';
+import { Directive, OnInit, OnDestroy } from '@angular/core';
 
 @Directive({
   selector: '[appBraintreescript]'
 })
-export class BraintreescriptDirective implements OnInit {
+export class BraintreescriptDirective implements OnInit, OnDestroy {
+
+  script: any;
 
   constructor() {
   }
 
   ngOnInit() {
-    let script = document.createElement("script");
-    script.type = "text/javascript";
-    script.src = "https://js.braintreegateway.com/web/dropin/1.8.0/js/dropin.min.js";
-    document.getElementsByTagName('body')[0].appendChild(script);
+    this.script = document.createElement("script");
+    this.script.type = "text/javascript";
+    this.script.src = "https://js.braintreegateway.com/web/dropin/1.8.0/js/dropin.min.js";
+    document.getElementsByTagName('body')[0].appendChild(this.script);
+  }
+
+  ngOnDestroy() {
+    document.getElementsByTagName('body')[0].removeChild(this.script);
   }
 }


### PR DESCRIPTION
The braintree library now gets removed when the component unloads. So, the braintree library gets added dynamically when the component is loaded and now also gets removed when no longer needed. 